### PR TITLE
fixed 2 issues

### DIFF
--- a/djangocms_link/fields.py
+++ b/djangocms_link/fields.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-if 'django_select2' in settings.INSTALLED_APPS:
+if 'django_select2' in settings.INSTALLED_APPS and getattr(settings, "DJANGOCMS_LINK_ENABLE_SELECT2", False):
     try:
 
         from django_select2.fields import AutoModelSelect2Field

--- a/djangocms_link/fields.py
+++ b/djangocms_link/fields.py
@@ -9,7 +9,7 @@ if 'django_select2' in settings.INSTALLED_APPS and getattr(settings, "DJANGOCMS_
         from django_select2.fields import AutoModelSelect2Field
 
         class PageSearchField(AutoModelSelect2Field):
-            empty_values = []
+            empty_value = []
             search_fields = ['title_set__title__icontains', 'title_set__menu_title__icontains', 'title_set__slug__icontains']
 
             def security_check(self, request, *args, **kwargs):

--- a/djangocms_link/fields.py
+++ b/djangocms_link/fields.py
@@ -1,4 +1,8 @@
 from django.conf import settings
+# to enable django_select2:
+# - the app must be in the installed apps
+# - the setting DJANGOCMS_LINK_ENABLE_SELECT2 must be set to True
+
 if 'django_select2' in settings.INSTALLED_APPS and getattr(settings, "DJANGOCMS_LINK_ENABLE_SELECT2", False):
     try:
 


### PR DESCRIPTION
1) made usage of select2 field configurable: https://github.com/divio/djangocms-link/issues/8
2) select2 field raised an exception if value was `[]` (no page selected):

When using empty_values, you declare what values are accepted (at the moment this was an empty list, meaning no empty values were accepted) ==> changing it to `empty_values = [[],]` would have fixed it.
Found out you can also declare only one empty_value => I found this more logical.
