### PR TITLE
Allow to put anchor links targetting the current page

### DIFF
--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -42,7 +42,7 @@ class Link(CMSPlugin):
             link = self.page_link.get_absolute_url()
         else:
             link = ""
-        if (self.url or self.page_link) and self.anchor:
+        if (self.url or self.page_link or not link) and self.anchor:
             link += '#' + self.anchor
         return link
 


### PR DESCRIPTION
This allows to leave all fields blank except anchor to put an anchor to the page the link is on.