### PR TITLE
fix for #34

### DIFF
--- a/djangocms_link/cms_plugins.py
+++ b/djangocms_link/cms_plugins.py
@@ -5,14 +5,12 @@ from django.conf import settings
 from cms.plugin_pool import plugin_pool
 from cms.plugin_base import CMSPluginBase
 
-from djangocms_link.forms import LinkForm
 from djangocms_link.models import Link
 
 
 class LinkPlugin(CMSPluginBase):
 
     model = Link
-    form = LinkForm
     name = _("Link")
     render_template = "cms/plugins/link.html"
     text_enabled = True


### PR DESCRIPTION
Maybe a fix for https://github.com/divio/djangocms-link/issues/34 ?!?

Because **get_form()** is defined, the **form = LinkForm** is not needed?!?

