### PR TITLE
Support internal hosts

### DIFF
--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -10,6 +14,14 @@ class Link(CMSPlugin):
     """
     A link to an other page or to an external website
     """
+
+    TARGET_CHOICES = (
+        ("", _("same window")),
+        ("_blank", _("new window")),
+        ("_parent", _("parent window")),
+        ("_top", _("topmost frame")),
+    )
+
     name = models.CharField(_("name"), max_length=256)
     url = models.URLField(_("link"), blank=True, null=True)
     page_link = models.ForeignKey(
@@ -20,16 +32,14 @@ class Link(CMSPlugin):
         help_text=_("A link to a page has priority over a text link."),
         on_delete=models.SET_NULL
     )
-    anchor = models.CharField(_("anchor"), max_length=128, blank=True, help_text=_("This applies only to page and text links."))
-    mailto = models.EmailField(_("mailto"), blank=True, null=True, help_text=_("An email address has priority over a text link."))
+    anchor = models.CharField(_("anchor"), max_length=128, blank=True,
+        help_text=_("This applies only to page and text links."))
+    mailto = models.EmailField(_("mailto"), blank=True, null=True,
+        help_text=_("An email address has priority over a text link."))
     phone = models.CharField(_('Phone'), blank=True, null=True, max_length=40,
-                             help_text=_('A phone number has priority over a mailto link.'))
-    target = models.CharField(_("target"), blank=True, max_length=100, choices=((
-        ("", _("same window")),
-        ("_blank", _("new window")),
-        ("_parent", _("parent window")),
-        ("_top", _("topmost frame")),
-    )))
+        help_text=_('A phone number has priority over a mailto link.'))
+    target = models.CharField(_("target"), blank=True, max_length=100,
+        choices=TARGET_CHOICES)
 
     def link(self):
         if self.phone:
@@ -49,5 +59,4 @@ class Link(CMSPlugin):
     def __str__(self):
         return self.name
 
-    search_fields = ('name',)
-
+    search_fields = ('name', )

--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -2,11 +2,14 @@
 
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from cms.models import CMSPlugin, Page
 from cms.utils.compat.dj import python_2_unicode_compatible
+
+from .validators import IntranetURLValidator
 
 
 @python_2_unicode_compatible
@@ -22,8 +25,13 @@ class Link(CMSPlugin):
         ("_top", _("topmost frame")),
     )
 
+    url_validators = [IntranetURLValidator(intranet_host_re=getattr(
+        settings, "DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN", None)), ]
+
     name = models.CharField(_("name"), max_length=256)
-    url = models.URLField(_("link"), blank=True, null=True)
+    # Re: max_length, see: http://stackoverflow.com/questions/417142/
+    url = models.CharField(_("link"), blank=True, null=True,
+        validators=url_validators, max_length=2048)
     page_link = models.ForeignKey(
         Page,
         verbose_name=_("page"),

--- a/djangocms_link/validators.py
+++ b/djangocms_link/validators.py
@@ -38,7 +38,8 @@ class IntranetURLValidator(URLValidator):
     def __init__(self, intranet_host_re=None, **kwargs):
         super(IntranetURLValidator, self).__init__(**kwargs)
         if intranet_host_re:
-            self.host_re = '(' + self.hostname_re + self.domain_re + self.tld_re + '|' + intranet_host_re + '|localhost)'
+            self.host_re = ('(' + self.hostname_re + self.domain_re + 
+                self.tld_re + '|' + intranet_host_re + '|localhost)')
             self.regex = re.compile(
                 r'^(?:[a-z0-9\.\-]*)://'
                 r'(?:\S+(?::\S*)?@)?'

--- a/djangocms_link/validators.py
+++ b/djangocms_link/validators.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import re
+
+from django.conf import settings
+from django.core.validators import URLValidator
+from django.utils.deconstruct import deconstructible
+
+
+@deconstructible
+class IntranetURLValidator(URLValidator):
+    """
+    This is essentially the normal, Django URL Validator, but allows for
+    "internal" machine-name only "hostnames" as defined by the RegEx pattern
+    defined in settings as well as normal, FQD-based hostnames.
+
+    Some examples:
+    RFC1123 Pattern
+        DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN = r'[a-z,0-9,-]{1,15}'
+    NetBios Pattern
+        DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN = r'[a-z,0-9,!@#$%^()\\-\'{}.~]{1,15}'
+    """
+
+    ul = '\u00a1-\uffff'  # unicode letters range (must be a unicode string, not a raw string)
+
+    # IP patterns
+    ipv4_re = r'(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}'
+    ipv6_re = r'\[[0-9a-f:\.]+\]'  # (simple regex, validated later)
+
+    # Host patterns
+    hostname_re = r'[a-z' + ul + r'0-9](?:[a-z' + ul + r'0-9-]*[a-z' + ul + r'0-9])?'
+    domain_re = r'(?:\.[a-z' + ul + r'0-9]+(?:[a-z' + ul + r'0-9-]*[a-z' + ul + r'0-9]+)*)*'
+    tld_re = r'\.[a-z' + ul + r']{2,}\.?'
+    host_re = '(' + hostname_re + domain_re + tld_re + '|localhost)'
+
+    def __init__(self, intranet_host_re=None, **kwargs):
+        super(IntranetURLValidator, self).__init__(**kwargs)
+        if intranet_host_re:
+            self.host_re = '(' + self.hostname_re + self.domain_re + self.tld_re + '|' + intranet_host_re + '|localhost)'
+            self.regex = re.compile(
+                r'^(?:[a-z0-9\.\-]*)://'
+                r'(?:\S+(?::\S*)?@)?'
+                r'(?:' + self.ipv4_re + '|' + self.ipv6_re + '|' + self.host_re + ')'
+                r'(?::\d{2,5})?'
+                r'(?:[/?#][^\s]*)?'
+                r'$', re.IGNORECASE)


### PR DESCRIPTION
Provides support for *additional* hostname patterns by configuring the setting: DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN

This is useful for intranet environments where it is valid to reference NETBIOS or NETBEUI, et al names across the network.

The setting should contain a valid regex pattern, here's some samples:

RFC1123: `r'[a-z,0-9,-]{1,15}'`
NetBIOS: `r'[a-z,0-9,!@#$%^()\\-\'{}.~]{1,15}'`