### PR TITLE
link model django migration

### DIFF
--- a/djangocms_link/migrations_django/0004_auto_20150708_1133.py
+++ b/djangocms_link/migrations_django/0004_auto_20150708_1133.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import djangocms_link.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_link', '0003_auto_20150212_1310'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='link',
+            name='anchor',
+            field=models.CharField(help_text='This applies only to page and text links. Do <em>not</em> include a preceding "#" symbol.', max_length=128, verbose_name='anchor', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='link',
+            name='url',
+            field=models.CharField(blank=True, max_length=2048, null=True, verbose_name='link', validators=[djangocms_link.validators.IntranetURLValidator(intranet_host_re=None)]),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
@mkoistinen It seems you forget create migration after changes in `Link.anchor.help_text` and `Link.url`: https://github.com/divio/djangocms-link/commit/d1a48c9e737972d52e0e73f04b729f1b8be316a7 https://github.com/divio/djangocms-link/commit/3d0b712d87386915a6032ddba963a086130af585