### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ host-portion of the URL.
 
 For example: ::
 
-    # RFC1123 Pattern:
+    # RFC1123 Pattern:
     DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN = r'[a-z,0-9,-]{1,15}'
 
     # NetBios Pattern:


### PR DESCRIPTION
https://github.com/divio/djangocms-link/issues/56

There is a unicode space {U+00A0} at line 50 of README.rst:

    #{U+00A0}RFC1123 Pattern:

issues#56 could be closed, and 
https://github.com/divio/djangocms-link/pull/62/commits
maybe no longer needed