### PR TITLE
Pin select2 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ env*
 .tox
 .coverage
 .eggs
+.idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 
 ----------
-XXXX-XX-XX
+2015-10-14
+----------
+
+Version 1.7.1
+
+* Pin Django Select2 to >=4.3,<5.0 to preserve Django 1.6 compatibility
+
+----------
+2015-10-12
 ----------
 
 Version 1.7

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email='info@divio.ch',
     url='https://github.com/divio/djangocms-link',
     packages=['djangocms_link', 'djangocms_link.migrations', 'djangocms_link.south_migrations'],
-    install_requires=['django-select2>=4.3'],
+    install_requires=['django-select2>=4.3,<5.0'],
     license='LICENSE.txt',
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
Django Select2 version 5.0 is not compatible with Django 1.6.