### PR TITLE
Hide draft pages from page link list

### DIFF
--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -39,7 +39,8 @@ class AbstractLink(CMSPlugin):
         blank=True,
         null=True,
         help_text=_('A link to a page has priority over a text link.'),
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
+        limit_choices_to={'publisher_is_draft': False},
     )
     anchor = models.CharField(_('anchor'), max_length=128, blank=True,
                               help_text=_('This applies only to page and text links.'


### PR DESCRIPTION
Currently, both draft and published `Page` objects appear in the page list for the `Link` plugin, meaning each page is in the list twice. This change filters the list to only show published pages.