### PR TITLE
Fixed styling issues with attributes field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+----------
+Unreleased
+----------
+
+Version 1.8.2
+
+* Fixed styling issues with attributes field
 
 ----------
 2016-07-05

--- a/djangocms_link/forms.py
+++ b/djangocms_link/forms.py
@@ -36,8 +36,7 @@ class LinkForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(LinkForm, self).__init__(*args, **kwargs)
-        self.fields['attributes'].widget = AttributesWidget(
-            val_attrs={'style': 'width:500px!important'})
+        self.fields['attributes'].widget = AttributesWidget()
 
     def _get_media(self):
         """


### PR DESCRIPTION
Since https://github.com/divio/djangocms-attributes-field/pull/14/
it is no longer required to pass custom width for the input since
it is going to be handled correctly by the field itself.