### PR TITLE
Added aldryn config

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -1,0 +1,6 @@
+{
+    "package-name": "djangocms-link",
+    "installed-apps": [
+        "djangocms_link"
+    ]
+}

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,6 @@ skip_install = true
 
 [flake8]
 ignore = E251,E128
-exclude = djangocms_link/tests/*,djangocms_link/migrations/*,djangocms_link/south_migrations/*,test_settings.py,build/*
+exclude = djangocms_link/tests/*,djangocms_link/migrations/*,djangocms_link/south_migrations/*,test_settings.py,build/*,.tox/*
 # max-line-length should be 80
 max-line-length = 100


### PR DESCRIPTION
We assume `django_select2` has been setup by Aldryn Django CMS