### PR TITLE
Fixed django.db.utils.IntegrityError issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog
 =========
 
 
+2.0.1 (unreleased)
+==================
+- Fixed an issues with migrations where Null values caused ``IntegrityError``
+
+
 2.0.0 (2016-15-08)
 ==================
 

--- a/djangocms_link/migrations/0010_adapted_fields.py
+++ b/djangocms_link/migrations/0010_adapted_fields.py
@@ -7,6 +7,14 @@ import djangocms_attributes_field.fields
 import djangocms_link.validators
 
 
+def reset_null_values(apps, schema_editor):
+    Link = apps.get_model('djangocms_link', 'Link')
+    plugins = Link.objects.all()
+    plugins.filter(url__isnull=True).update(url='')
+    plugins.filter(mailto__isnull=True).update(mailto='')
+    plugins.filter(phone__isnull=True).update(phone='')
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -14,6 +22,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(reset_null_values),
         migrations.AddField(
             model_name='link',
             name='template',

--- a/djangocms_link/migrations/0010_adapted_fields.py
+++ b/djangocms_link/migrations/0010_adapted_fields.py
@@ -7,14 +7,6 @@ import djangocms_attributes_field.fields
 import djangocms_link.validators
 
 
-def reset_null_values(apps, schema_editor):
-    Link = apps.get_model('djangocms_link', 'Link')
-    plugins = Link.objects.all()
-    plugins.filter(url__isnull=True).update(url='')
-    plugins.filter(mailto__isnull=True).update(mailto='')
-    plugins.filter(phone__isnull=True).update(phone='')
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -22,7 +14,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(reset_null_values),
         migrations.AddField(
             model_name='link',
             name='template',
@@ -50,28 +41,13 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name='link',
-            name='external_link',
-            field=models.URLField(blank=True, max_length=2040, verbose_name='External link', help_text='Provide a valid URL to an external website.', validators=[djangocms_link.validators.IntranetURLValidator(intranet_host_re=None)]),
-        ),
-        migrations.AlterField(
-            model_name='link',
             name='internal_link',
             field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, blank=True, to='cms.Page', help_text='If provided, overrides the external link.', null=True, verbose_name='Internal link'),
         ),
         migrations.AlterField(
             model_name='link',
-            name='mailto',
-            field=models.EmailField(max_length=255, verbose_name='Email address', blank=True),
-        ),
-        migrations.AlterField(
-            model_name='link',
             name='name',
             field=models.CharField(max_length=255, verbose_name='Display name', blank=True),
-        ),
-        migrations.AlterField(
-            model_name='link',
-            name='phone',
-            field=models.CharField(max_length=255, verbose_name='Phone', blank=True),
         ),
         migrations.AlterField(
             model_name='link',

--- a/djangocms_link/migrations/0011_fixed_null_values.py
+++ b/djangocms_link/migrations/0011_fixed_null_values.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def reset_null_values(apps, schema_editor):
+    Link = apps.get_model('djangocms_link', 'Link')
+    plugins = Link.objects.all()
+    plugins.filter(external_link__isnull=True).update(external_link='')
+    plugins.filter(mailto__isnull=True).update(mailto='')
+    plugins.filter(phone__isnull=True).update(phone='')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_link', '0010_adapted_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(reset_null_values),
+    ]

--- a/djangocms_link/migrations/0012_removed_null.py
+++ b/djangocms_link/migrations/0012_removed_null.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import djangocms_link.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_link', '0011_fixed_null_values'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='link',
+            name='external_link',
+            field=models.URLField(default='', validators=[djangocms_link.validators.IntranetURLValidator(intranet_host_re=None)], max_length=2040, blank=True, help_text='Provide a valid URL to an external website.', verbose_name='External link'),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='link',
+            name='mailto',
+            field=models.EmailField(default='', max_length=255, verbose_name='Email address', blank=True),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='link',
+            name='phone',
+            field=models.CharField(default='', max_length=255, verbose_name='Phone', blank=True),
+            preserve_default=False,
+        ),
+    ]


### PR DESCRIPTION
This needed further adaptions to work on the following scenarios:

- Install the addon from scratch
- Upgrading the addon from 1.8.3 to 2.0.0 and then 2.0.1
- Upgrading the addon from 2.0.0 to 2.0.1
- Upgrading the addon from failing (IntegrityError) 2.0.0 to 2.0.1