### PR TITLE
adapted testing infrastructure, fixed migrations and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ env:
   - TOX_ENV=py27-latest
   - TOX_ENV=py34-latest
   # Django 1.8
-  - TOX_ENV=py34-dj18-cms33
-  - TOX_ENV=py34-dj18-cms32
+  - TOX_ENV=py27-dj18-cms34
   - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py27-dj18-cms32
+  - TOX_ENV=py34-dj18-cms34
+  - TOX_ENV=py34-dj18-cms33
   # Django 1.9
-  - TOX_ENV=py34-dj19-cms33
-  - TOX_ENV=py34-dj19-cms32
+  - TOX_ENV=py27-dj19-cms34
   - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py27-dj19-cms32
+  - TOX_ENV=py34-dj19-cms34
+  - TOX_ENV=py34-dj19-cms33
 
 install:
   - pip install tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Changelog
 * Changed naming of ``Aldryn`` to ``Divio Cloud``
 * Adapted testing infrastructure (tox/travis) to incorporate
   django CMS 3.4 and dropped 3.2
-* Removed NetBios Pattern from documentations as its faulty
+* Removed NetBios Pattern from documentations as its incorrect
 
 
 2.0.2 (2016-10-31)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog
 =========
 
 
+2.0.3 (unreleased)
+==================
+* Prevent changes to ``DJANGOCMS_LINK_XXX`` settings from requiring new
+  migrations
+* Changed naming of ``Aldryn`` to ``Divio Cloud``
+* Adapted testing infrastructure (tox/travis) to incorporate
+  django CMS 3.4 and dropped 3.2
+* Removed NetBios Pattern from documentations as its faulty
+
+
 2.0.2 (2016-10-31)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ allows you to add links on your site.
 This plugin supports child plugins. If you add an other plugin as a
 child it will take this content instead of the link name as the content of the link.
 
-This addon is compatible with `Aldryn <http://aldryn.com>`_ and is also available on the
+This addon is compatible with `Divio Cloud <http://divio.com>`_ and is also available on the
 `django CMS Marketplace <https://marketplace.django-cms.org/en/addons/browse/djangocms-link/>`_
 for easy installation.
 
@@ -77,9 +77,6 @@ For example: ::
 
     # RFC1123 Pattern:
     DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN = r'[a-z,0-9,-]{1,15}'
-
-    # NetBios Pattern:
-    DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN = r'[a-z,0-9,!@#$%^()\\-\'{}.~]{1,15}'
 
 Either of these might accept a URL such as: ::
 

--- a/djangocms_link/migrations/0004_auto_20150708_1133.py
+++ b/djangocms_link/migrations/0004_auto_20150708_1133.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 import djangocms_link.validators
+from djangocms_link.models import HOSTNAME
 
 
 class Migration(migrations.Migration):
@@ -21,7 +22,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='link',
             name='url',
-            field=models.CharField(blank=True, max_length=2048, null=True, verbose_name='link', validators=[djangocms_link.validators.IntranetURLValidator(intranet_host_re=None)]),
+            field=models.CharField(blank=True, max_length=2048, null=True, verbose_name='link', validators=[djangocms_link.validators.IntranetURLValidator(intranet_host_re=HOSTNAME)]),
             preserve_default=True,
         ),
     ]

--- a/djangocms_link/migrations/0010_adapted_fields.py
+++ b/djangocms_link/migrations/0010_adapted_fields.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.db.models.deletion
 import djangocms_attributes_field.fields
-import djangocms_link.validators
+from djangocms_link.models import get_templates
 
 
 class Migration(migrations.Migration):
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='link',
             name='template',
-            field=models.CharField(default='default', max_length=255, verbose_name='Template', choices=[('default', 'Default')]),
+            field=models.CharField(default=get_templates()[0][0], max_length=255, verbose_name='Template', choices=get_templates()),
         ),
         migrations.RenameField(
             model_name='link',

--- a/djangocms_link/migrations/0013_fix_hostname.py
+++ b/djangocms_link/migrations/0013_fix_hostname.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import djangocms_link.validators
+from djangocms_link.models import HOSTNAME
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_link', '0012_removed_null'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='link',
+            name='external_link',
+            field=models.URLField(blank=True, help_text='Provide a valid URL to an external website.', max_length=2040, verbose_name='External link', validators=[djangocms_link.validators.IntranetURLValidator(intranet_host_re=HOSTNAME)]),
+        ),
+    ]

--- a/djangocms_link/validators.py
+++ b/djangocms_link/validators.py
@@ -13,8 +13,6 @@ class IntranetURLValidator(URLValidator):
     Some examples:
     RFC1123 Pattern
         DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN = r'[a-z,0-9,-]{1,15}'
-    NetBios Pattern
-        DJANGOCMS_LINK_INTRANET_HOSTNAME_PATTERN = r'[a-z,0-9,!@#$%^()\\-\'{}.~]{1,15}'
     """
 
     ul = '\u00a1-\uffff'  # unicode letters range (must be a unicode string, not a raw string)

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     py{34,27}-latest
-    py{34,27}-dj18-cms{33,32}
-    py{34,27}-dj19-cms{33,32}
+    py{34,27}-dj18-cms{34,33}
+    py{34,27}-dj19-cms{34,33}
 
 skip_missing_interpreters=True
 
@@ -14,8 +14,8 @@ deps =
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     latest: django-cms
-    cms32: django-cms>=3.2,<3.3
     cms33: django-cms>=3.3,<3.4
+    cms34: django-cms>=3.4,<3.5
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
* Prevent changes to ``DJANGOCMS_LINK_XXX`` settings from requiring new
  migrations
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2
* Removed NetBios Pattern from documentations as its faulty
