### PR TITLE
Release version 2.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,9 @@ Changelog
 =========
 
 
-2.0.3 (unreleased)
+2.0.3 (2016-11-22)
 ==================
+
 * Prevent changes to ``DJANGOCMS_LINK_XXX`` settings from requiring new
   migrations
 * Changed naming of ``Aldryn`` to ``Divio Cloud``

--- a/djangocms_link/__init__.py
+++ b/djangocms_link/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.0.2'
+__version__ = '2.0.3'


### PR DESCRIPTION
* Prevent changes to ``DJANGOCMS_LINK_XXX`` settings from requiring new
  migrations
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2
* Removed NetBios Pattern from doccd umentations as its incorrect
* Updated translations