### PR TITLE
we started to support new django-select2 versions. #78

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.egg-info
+*.egg/
 .DS_Store
 .idea/
 .tox/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+2.0.4 (2016-12-08)
+==================
+
+* Supported new django-select2 versions
+* Removed unnecessary ``UserSearchField``
+
 
 2.0.3 (2016-11-22)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,11 @@
 Changelog
 =========
 
-2.0.4 (2016-12-08)
+2.1.0 (unreleased)
 ==================
 
 * Supported new django-select2 versions
-* Removed unnecessary ``UserSearchField``
+* Remove unused ``UserSearchField``
 
 
 2.0.3 (2016-11-22)

--- a/djangocms_link/fields.py
+++ b/djangocms_link/fields.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 from django.conf import settings
 
 ENABLE_SELECT2 = getattr(settings, 'DJANGOCMS_LINK_USE_SELECT2', False)
@@ -5,8 +7,8 @@ ENABLE_SELECT2 = getattr(settings, 'DJANGOCMS_LINK_USE_SELECT2', False)
 if ENABLE_SELECT2 and 'django_select2' in settings.INSTALLED_APPS:
     import django_select2
 
-    major_number = int(django_select2.__version__.split('.')[0])
-    if major_number >= 5:
+    select2_version = LooseVersion(django_select2.__version__)
+    if select2_version >= LooseVersion('5'):
         from djangocms_link.fields_select2 import Select2PageSearchField as PageSearchField
     else:
         from djangocms_link.fields_select2_legacy import Select2LegacyPageSearchField as PageSearchField

--- a/djangocms_link/fields.py
+++ b/djangocms_link/fields.py
@@ -10,7 +10,5 @@ if ENABLE_SELECT2 and 'django_select2' in settings.INSTALLED_APPS:
         from djangocms_link.fields_select2 import Select2PageSearchField as PageSearchField
     else:
         from djangocms_link.fields_select2_legacy import Select2LegacyPageSearchField as PageSearchField
-        from djangocms_link.fields_select2_legacy import Select2LegacyUserSearchField as UserSearchField
-
 else:
     from cms.forms.fields import PageSelectFormField as PageSearchField

--- a/djangocms_link/fields.py
+++ b/djangocms_link/fields.py
@@ -1,54 +1,16 @@
-# -*- coding: utf-8 -*-
 from django.conf import settings
 
-
-ENABLE_SELECT2 = getattr(
-    settings,
-    'DJANGOCMS_LINK_USE_SELECT2',
-    False
-)
-
+ENABLE_SELECT2 = getattr(settings, 'DJANGOCMS_LINK_USE_SELECT2', False)
 
 if ENABLE_SELECT2 and 'django_select2' in settings.INSTALLED_APPS:
-    from django_select2.fields import AutoModelSelect2Field
+    import django_select2
 
-    class PageSearchField(AutoModelSelect2Field):
-        site = None
-        search_fields = [
-            'title_set__title__icontains',
-            'title_set__menu_title__icontains',
-            'title_set__slug__icontains'
-        ]
+    major_number = int(django_select2.__version__.split('.')[0])
+    if major_number >= 5:
+        from djangocms_link.fields_select2 import Select2PageSearchField as PageSearchField
+    else:
+        from djangocms_link.fields_select2_legacy import Select2LegacyPageSearchField as PageSearchField
+        from djangocms_link.fields_select2_legacy import Select2LegacyUserSearchField as UserSearchField
 
-        def get_queryset(self):
-            from cms.models import Page
-            if self.site:
-                return Page.objects.drafts().on_site(self.site)
-            else:
-                return Page.objects.drafts()
-
-        def security_check(self, request, *args, **kwargs):
-            user = request.user
-            if user and not user.is_anonymous() and user.is_staff:
-                return True
-            return False
-
-    class UserSearchField(AutoModelSelect2Field):
-        search_fields = [
-            'username__icontains',
-            'firstname__icontains',
-            'lastname__icontains'
-        ]
-
-        def security_check(self, request, *args, **kwargs):
-            user = request.user
-            if user and not user.is_anonymous() and user.is_staff:
-                return True
-            return False
-
-        def prepare_value(self, value):
-            if not value:
-                return None
-            return super(UserSearchField, self).prepare_value(value)
 else:
     from cms.forms.fields import PageSelectFormField as PageSearchField

--- a/djangocms_link/fields_select2.py
+++ b/djangocms_link/fields_select2.py
@@ -1,0 +1,25 @@
+from cms.models import Page
+from django import forms
+from django_select2.forms import ModelSelect2Widget
+
+
+class Select2PageSearchFieldMixin(object):
+    search_fields = [
+        'title_set__title__icontains',
+        'title_set__menu_title__icontains',
+        'title_set__slug__icontains'
+    ]
+
+
+class Select2PageSelectWidget(Select2PageSearchFieldMixin, ModelSelect2Widget):
+    def __init__(self, site=None, *args, **kwargs):
+        self.site = site
+        super(Select2PageSelectWidget, self).__init__(*args, **kwargs)
+
+    def get_queryset(self):
+        return Page.objects.drafts().on_site(self.site) if self.site is not None else Page.objects.drafts()
+
+
+class Select2PageSearchField(forms.ChoiceField):
+    site = None
+    widget = Select2PageSelectWidget(site=site)

--- a/djangocms_link/fields_select2_legacy.py
+++ b/djangocms_link/fields_select2_legacy.py
@@ -1,0 +1,31 @@
+from cms.models import Page
+from django_select2.fields import AutoModelSelect2Field
+
+
+class Select2LegacyPageSearchField(AutoModelSelect2Field):
+    site = None
+    search_fields = [
+        'title_set__title__icontains',
+        'title_set__menu_title__icontains',
+        'title_set__slug__icontains'
+    ]
+
+    def get_queryset(self):
+        return Page.objects.drafts().on_site(self.site) if self.site is not None else Page.objects.drafts()
+
+    def security_check(self, request, *args, **kwargs):
+        return request.user and not request.user.is_anonymous() and request.user.is_staff
+
+
+class Select2LegacyUserSearchField(AutoModelSelect2Field):
+    search_fields = [
+        'username__icontains',
+        'firstname__icontains',
+        'lastname__icontains'
+    ]
+
+    def security_check(self, request, *args, **kwargs):
+        return request.user and not request.user.is_anonymous() and request.user.is_staff
+
+    def prepare_value(self, value):
+        return None if not value else super(Select2LegacyUserSearchField, self).prepare_value(value)

--- a/djangocms_link/fields_select2_legacy.py
+++ b/djangocms_link/fields_select2_legacy.py
@@ -15,17 +15,3 @@ class Select2LegacyPageSearchField(AutoModelSelect2Field):
 
     def security_check(self, request, *args, **kwargs):
         return request.user and not request.user.is_anonymous() and request.user.is_staff
-
-
-class Select2LegacyUserSearchField(AutoModelSelect2Field):
-    search_fields = [
-        'username__icontains',
-        'firstname__icontains',
-        'lastname__icontains'
-    ]
-
-    def security_check(self, request, *args, **kwargs):
-        return request.user and not request.user.is_anonymous() and request.user.is_staff
-
-    def prepare_value(self, value):
-        return None if not value else super(Select2LegacyUserSearchField, self).prepare_value(value)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 # requirements from setup.py
-django-select2>=4.3,<5.0
+django-select2>=5.0
 # other requirements
 djangocms-text-ckeditor
 html5lib<0.99999999

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 HELPER_SETTINGS = {
     'INSTALLED_APPS': [
         'django_select2',
@@ -14,11 +11,14 @@ HELPER_SETTINGS = {
         }]
     },
     'LANGUAGE_CODE': 'en',
+    'DJANGOCMS_LINK_USE_SELECT2': True
 }
+
 
 def run():
     from djangocms_helper import runner
     runner.cms('djangocms_link')
+
 
 if __name__ == '__main__':
     run()

--- a/tests/tests_field.py
+++ b/tests/tests_field.py
@@ -1,0 +1,8 @@
+from djangocms_helper.base_test import BaseTestCase
+from djangocms_link.fields import PageSearchField
+from djangocms_link.fields_select2 import Select2PageSearchField
+
+
+class FieldTestCase(BaseTestCase):
+    def test_field_with_django_select2_extension(self):
+        self.assertEqual(PageSearchField, Select2PageSearchField)


### PR DESCRIPTION
This is a proposal. I think we should discuss about my way of supporting the old versions of django-select2 for backward compatibility. And I see some unwanted style problems (incompatible input view with other inputs).

And the other thing, I couldn't find any use of `UserSearchField`. Should we keep this method or remove it completely?

![new_select2](https://cloud.githubusercontent.com/assets/72323/20860404/6640a6ec-b988-11e6-9f21-c03e042c1a1d.png)

