### PR TITLE
Better link validation

### DIFF
--- a/djangocms_link/forms.py
+++ b/djangocms_link/forms.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from django.forms import ValidationError
 from django.forms.models import ModelForm
-from django.forms.widgets import Media
-from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from djangocms_attributes_field.widgets import AttributesWidget
@@ -36,60 +33,3 @@ class LinkForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(LinkForm, self).__init__(*args, **kwargs)
         self.fields['attributes'].widget = AttributesWidget()
-
-    def clean(self):
-        cleaned_data = super(LinkForm, self).clean()
-        field_names = (
-            'external_link',
-            'internal_link',
-            'mailto',
-            'phone',
-        )
-        anchor_field_name = 'anchor'
-        field_names_allowed_with_anchor = (
-            'external_link',
-            'internal_link',
-        )
-
-        anchor_field_verbose_name = force_text(
-            getattr(self.fields.get(anchor_field_name), 'label'))
-        anchor_field_value = cleaned_data.get(anchor_field_name)
-
-        link_fields = {
-            key: cleaned_data.get(key)
-            for key in field_names
-        }
-        link_field_verbose_names = {
-            key: force_text(getattr(self.fields.get(key), 'label'))
-            for key in link_fields.keys()
-        }
-        provided_link_fields = {
-            key: value
-            for key, value in link_fields.items()
-            if value
-        }
-
-        if len(provided_link_fields) > 1:
-            # Too many fields have a value.
-            error_msg = '{} {}'.format(
-                _('Only one of these fields is allowed:'),
-                ', '.join(link_field_verbose_names.values()),
-            )
-            errors = {}
-            for field, value in link_fields.items():
-                if value:
-                    errors[field] = error_msg
-            raise ValidationError(errors)
-
-        if anchor_field_value:
-            for field_name in provided_link_fields.keys():
-                if field_name not in field_names_allowed_with_anchor:
-                    error_msg = _('%(anchor_field_verbose_name)s is not allowed together with %(field_name)s') % {
-                        'anchor_field_verbose_name': anchor_field_verbose_name,
-                        'field_name': link_field_verbose_names.get(field_name)
-                    }
-                    raise ValidationError({
-                        anchor_field_name: error_msg,
-                        field_name: error_msg,
-                    })
-        return cleaned_data

--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -185,7 +185,7 @@ class AbstractLink(CMSPlugin):
             # Too many fields have a value.
             error_msg = '{} {}'.format(
                 _('Only one of these fields is allowed:'),
-                ', '.join(link_field_verbose_names.values()),
+                ', '.join(sorted(link_field_verbose_names.values())),
             )
             errors = {}
             for field, value in link_fields.items():

--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -159,16 +159,12 @@ class AbstractLink(CMSPlugin):
             'internal_link',
         )
 
-        cleaned_data = {
-            key: getattr(self, key)
-            for key in field_names + (anchor_field_name,)
-        }
         anchor_field_verbose_name = force_text(
            self._meta.get_field_by_name(anchor_field_name)[0].verbose_name)
-        anchor_field_value = cleaned_data.get(anchor_field_name)
+        anchor_field_value = getattr(self, anchor_field_name)
 
         link_fields = {
-            key: cleaned_data.get(key)
+            key: getattr(self, key)
             for key in field_names
         }
         link_field_verbose_names = {
@@ -180,17 +176,14 @@ class AbstractLink(CMSPlugin):
             for key, value in link_fields.items()
             if value
         }
-
         if len(provided_link_fields) > 1:
             # Too many fields have a value.
-            error_msg = '{} {}'.format(
-                _('Only one of these fields is allowed:'),
-                ', '.join(sorted(link_field_verbose_names.values())),
+            verbose_names = sorted(link_field_verbose_names.values())
+            error_msg = _('Only one of %s or %s may be given.') % (
+                ', '.join(verbose_names[:-1]),
+                verbose_names[-1],
             )
-            errors = {}
-            for field, value in link_fields.items():
-                if value:
-                    errors[field] = error_msg
+            errors = {}.fromkeys(provided_link_fields.keys(), error_msg)
             raise ValidationError(errors)
 
         if anchor_field_value:


### PR DESCRIPTION
Validates that only one of the link-ish fields can be filled at the same
time.
Respects special cases with anchor.

(*Sorry for mixed languages in screenshots*)

![screen shot 2016-12-27 at 17 14 03](https://cloud.githubusercontent.com/assets/14330/21503615/1db9154c-cc59-11e6-800e-628ae5c42827.png)
![screen shot 2016-12-27 at 17 13 35](https://cloud.githubusercontent.com/assets/14330/21503616/20970f94-cc59-11e6-8f61-5bfe6ce22383.png)


- [x] initial implementation and PR
- [ ] translations for new strings (over transifex after merging)