### PR TITLE
Release version 2.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.1.2 (unreleased)
+2.1.2 (2017-05-09)
 ==================
 
 * Fixed a bug which prevented links from working when the page

--- a/djangocms_link/__init__.py
+++ b/djangocms_link/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.1.1'
+__version__ = '2.1.2'


### PR DESCRIPTION
* Fixed a bug which prevented links from working when the page
  referenced is on a different site from the one that contains the plugin.
* Updated translations