### PR TITLE
Fixed DontUsePageAttributeWarning message

### DIFF
--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -134,8 +134,10 @@ class AbstractLink(CMSPlugin):
         if self.internal_link:
             ref_page = self.internal_link
             link = ref_page.get_absolute_url()
-
-            if ref_page.site_id != getattr(self.page, 'site_id', None):
+            
+            # simulate unauthorized CMSPlugin page property
+            mypage = self.placeholder.page if self.placeholder_id else None
+            if ref_page.site_id != getattr(mypage, 'site_id', None):
                 ref_site = Site.objects._get_site_by_id(ref_page.site_id).domain
                 link = '//{}{}'.format(ref_site, link)
         elif self.external_link:

--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -134,10 +134,10 @@ class AbstractLink(CMSPlugin):
         if self.internal_link:
             ref_page = self.internal_link
             link = ref_page.get_absolute_url()
-            
-            # simulate unauthorized CMSPlugin page property
-            mypage = self.placeholder.page if self.placeholder_id else None
-            if ref_page.site_id != getattr(mypage, 'site_id', None):
+
+            # simulate the call to the unauthorized CMSPlugin.page property
+            cms_page = self.placeholder.page if self.placeholder_id else None
+            if ref_page.site_id != getattr(cms_page, 'site_id', None):
                 ref_site = Site.objects._get_site_by_id(ref_page.site_id).domain
                 link = '//{}{}'.format(ref_site, link)
         elif self.external_link:


### PR DESCRIPTION
Fix spurious warning messages "cms/models/pluginmodel.py:308: DontUsePageAttributeWarning: Don't use the page attribute on CMSPlugins! CMSPlugins are not guaranteed to have a page associated with them!".
They were emitted from https://github.com/divio/django-cms/blob/3.4.4/cms/models/pluginmodel.py#L304
called from https://github.com/divio/djangocms-link/blob/2.1.2/djangocms_link/models.py#L138

Also this pull-request may fix #133 