### PR TITLE
initial Django 2.0 support

### DIFF
--- a/djangocms_link/migrations/0001_initial.py
+++ b/djangocms_link/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Link',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True)),
+                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True, on_delete=models.CASCADE)),
                 ('name', models.CharField(verbose_name='name', max_length=256)),
                 ('url', models.URLField(verbose_name='link', blank=True, null=True)),
                 ('anchor', models.CharField(help_text='This applies only to page and text links.', blank=True, default='', max_length=128, verbose_name='anchor')),

--- a/djangocms_link/models.py
+++ b/djangocms_link/models.py
@@ -117,6 +117,7 @@ class AbstractLink(CMSPlugin):
         CMSPlugin,
         related_name='%(app_label)s_%(class)s',
         parent_link=True,
+        on_delete=models.CASCADE,
     )
 
     class Meta:


### PR DESCRIPTION
Squashing some incompatibilities between Django 1.11 and 2.0.

django-cms is not Django 2.0 ready yet, but I'm trying to get various plugins and dependencies compatible to make it easier for the whole ecosystem to work on 2.0.x eventually.