### PR TITLE
Bumped version to 2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-2.3.0 (unreleased)
+2.3.0 (2018-12-11)
 ==================
 
 * Fixed test matrix
@@ -10,7 +10,7 @@ Changelog
 * Fixed an issue generating ``'Page' object has no attribute 'site'``
 
 
-2.2.2 (2018-01-03)
+2.2.2 (2018-12-03)
 ==================
 
 * Fixed node attribute error

--- a/djangocms_link/__init__.py
+++ b/djangocms_link/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.2.2'
+__version__ = '2.3.0'


### PR DESCRIPTION
* Fixed test matrix
* Fixed an issue when ``page.site`` is not available
* Fixed an issue generating ``'Page' object has no attribute 'site'``