### PR TITLE
Bumped version to 2.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.5.0 (unreleased)
+2.5.0 (2019-07-09)
 ==================
 
 * Added file link support

--- a/djangocms_link/__init__.py
+++ b/djangocms_link/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.4.0'
+__version__ = '2.5.0'


### PR DESCRIPTION
* Added file link support
* Allow link requirement to be changed when another
  CMS plugin inherits from AbstractLink
* Fixed a bug preventing ``HOSTNAME_PATTERN`` to work
* Updated translations
