### PR TITLE
Bumped version to 2.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.6.0 (unreleased)
+2.6.0 (2020-04-21)
 ==================
 
 * Added support for Django 3.0

--- a/djangocms_link/__init__.py
+++ b/djangocms_link/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.5.0'
+__version__ = '2.6.0'


### PR DESCRIPTION
* Added support for Django 3.0
* Added support for Python 3.8
* Pinned ``django-filer`` to 1.5.0
* Added further tests to raise coverage
* Fixed smaller issues found during testing
* Dropped support for django-select2 <= 4
* Dropped support for django-filer <= 1.4