### PR TITLE
fixed #183: AttributeError: 'Page' object has no attribute 'site'

### DIFF
--- a/djangocms_link/cms_plugins.py
+++ b/djangocms_link/cms_plugins.py
@@ -55,9 +55,9 @@ class LinkPlugin(CMSPluginBase):
     def get_form(self, request, obj=None, **kwargs):
         form_class = super(LinkPlugin, self).get_form(request, obj, **kwargs)
 
-        if obj and obj.page and obj.page.site:
+        if obj and obj.page and hasattr(obj.page, 'site') and obj.page.site:
             site = obj.page.site
-        elif self.page and self.page.site:
+        elif self.page and hasattr(self.page, 'site') and self.page.site:
             site = self.page.site
         else:
             site = Site.objects.get_current()


### PR DESCRIPTION
This error occurred to me when using djangocms_bootstrap4 Carousel whenever editing one of the Slider forms. (Installed fresh djangocms 3.7.2 with djangocms-installer)